### PR TITLE
Add conda-index 0.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,6 @@ test:
     - pip check
     - pytest -k test_index_on_single_subdir_1
 
-
-
 about:
   home: https://github.com/conda/conda-index
   summary: Create `repodata.json` for collections of conda packages.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,45 +10,52 @@ source:
   sha256: b3ca5248a714d355dff29b1c07f4f5b3088e9f660815b19bb40f0379664c744c
 
 build:
-  script: {{ PYTHON }} -m pip install --no-build-isolation . -vv
   number: 0
-  noarch: python
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
 
 requirements:
   host:
     - flit-core
-    - python >=3.7
+    - python
     - pip
   run:
-    - python >=3.7
+    - python
     - click >=8
     - conda >=4.12.0
-    - conda-package-streaming
+    - conda-package-streaming >=0.7.0
     - filelock
     - jinja2
     - more-itertools
     - PyYAML >=6
 
 test:
+  imports:
+    - conda_index.index
+  source_files:
+    - tests
   requires:
     - conda-build >=3.21.0
     - conda-package-handling >=1.9.0
     - coverage
+    - pip
     - pytest >=7
     - pytest-cov
     - pytest-mock
     - tomli
   commands:
+    - pip check
     - pytest -k test_index_on_single_subdir_1
-  imports:
-    - conda_index.index
-  source_files:
-    - tests
+
+
 
 about:
   home: https://github.com/conda/conda-index
   summary: Create `repodata.json` for collections of conda packages.
+  description: |
+    Create repodata.json for collections of conda packages.
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   doc_url: https://conda.github.io/conda-index
   dev_url: https://github.com/conda/conda-index


### PR DESCRIPTION
**Jira:** [PKG-878](https://anaconda.atlassian.net/browse/PKG-878)

The upstream source:
Releases: https://github.com/conda/conda-index/releases
License: https://github.com/conda/conda-index/blob/0.2.3/LICENSE
Requirements: https://github.com/conda/conda-index/blob/0.2.3/pyproject.toml

**Actions**:
- Skip `py<37`

- Remove `noarch python`

- Update `pip install` script with `--no-deps`

- Fix `python` in `host` and `run`

- Add pinning for `conda-package-streaming`

- Add `pip check`

- Add `description`

- Add `license_family`

