### PR TITLE
`conda-index 0.4.0` & `noarch`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: dc44fc779bdf34809c1c6b97131d983e71bc373590a12ef6226425d294141405
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
+  noarch: python
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: dc44fc779bdf34809c1c6b97131d983e71bc373590a12ef6226425d294141405
+  sha256: 0d83fd01af3c5b17860a86c1e217090a19b6e262114a242bc7f4ff212ed1e705
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
   noarch: python


### PR DESCRIPTION
conda-index 0.4.0

**Destination channel:** defaults

### Explanation of changes:

- add Python 3.12 support (via `noarch`)
- release latest 0.4.0 version