### PR TITLE
Update 0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - jinja2
     - more-itertools
     - ruamel.yaml
-    # - zstadard
+    - zstandard
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,6 @@ requirements:
     - flit-core
     - python
     - pip
-    - wheel
-    - setuptools
   run:
     - python
     - click >=8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - flit-core
+    - flit-core >=3.2,<4
     - python
     - pip
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,20 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 0d83fd01af3c5b17860a86c1e217090a19b6e262114a242bc7f4ff212ed1e705
+  sha256: 12d78ec6dc55f64ad68761108a416ebde3dc6472f257045ddfa45378980c9074
 
 build:
   number: 0
-  skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
-  noarch: python
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - flit-core
     - python
     - pip
+    - wheel
+    - setuptools
   run:
     - python
     - click >=8
@@ -29,6 +30,7 @@ requirements:
     - jinja2
     - more-itertools
     - ruamel.yaml
+    # - zstadard
 
 test:
   imports:
@@ -44,6 +46,7 @@ test:
     - pytest-cov
     - pytest-mock
     - tomli
+    - fsspec
   commands:
     - pip check
     - pytest -k test_index_on_single_subdir_1
@@ -64,3 +67,4 @@ extra:
     - AndresGuzman-Ballen
     - dholth
     - jharlow-intel
+    - kenodegard


### PR DESCRIPTION
## ☆Conda-Index 0.5.0 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5070)
[Upstream](https://github.com/conda/conda-index)
# Changes
- Updated version number and `sha256`
- Added recent dependencies for `testing` and `host`.