### PR TITLE
conda-index 0.6.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml-feedstock/pr16/2908ac2
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr7/0935049

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,8 @@ test:
     - aiohttp !=4.0.0a0, !=4.0.0a1
   commands:
     - pip check
-    - pytest -k test_index_on_single_subdir_1
+    # ModuleNotFoundError: No module named 'conda_build' for py313.
+    - pytest -k test_index_on_single_subdir_1  # [py<313]
 
 about:
   home: https://github.com/conda/conda-index

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 12d78ec6dc55f64ad68761108a416ebde3dc6472f257045ddfa45378980c9074
+  sha256: b096e34b048b494489ff41389ecc4b17b9f400dbf5b36ee2e39aa2558cc9a6c2
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
     - conda-package-streaming >=0.7.0
     - filelock
     - jinja2
-    - more-itertools
+    - msgpack-python
     - ruamel.yaml
     - zstandard
 
@@ -44,7 +44,9 @@ test:
     - pytest-cov
     - pytest-mock
     - tomli
+    # "fsspec[http]" expands to 'http = ["aiohttp !=4.0.0a0, !=4.0.0a1"]''
     - fsspec
+    - aiohttp !=4.0.0a0, !=4.0.0a1
   commands:
     - pip check
     - pytest -k test_index_on_single_subdir_1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,8 @@ test:
   source_files:
     - tests
   requires:
-    - conda-build >=3.21.0
+    # Skip conda-build for py313 because conda-index is a cycle dependency
+    - conda-build >=3.21.0  # [py<313]
     - conda-package-handling >=1.9.0
     - coverage
     - pip


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8037](https://anaconda.atlassian.net/browse/PKG-8037)
- [Upstream repo](https://github.com/conda/conda-index/tree/0.6.0)
- release-diff: https://github.com/conda/conda-index/compare/0.5.0...0.6.0
- requirements-tagged: https://github.com/conda/conda-index/blob/0.6.0/pyproject.toml


### Explanation of changes:

- Replace `more-itertools` with `msgpack-python` at runtime
- Skip `conda-build` for py313 in `test.requires` because conda-index is a cycle dependency

[PKG-8037]: https://anaconda.atlassian.net/browse/PKG-8037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ