### PR TITLE
bumping conda-index version to 0.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 93034029c5d3b13ba4837d0b7813206c2faedf0a46bf25952d4d8a3882e31206
+  sha256: afbf3850b2197ab4ceb7785bee462e063bd498488c185112477cbe4197e70aad
 
 build:
   number: 0
@@ -27,6 +27,7 @@ requirements:
     - conda-package-streaming >=0.7.0
     - filelock
     - jinja2
+    # https://github.com/conda/conda-index/blob/0.7.0/recipe/meta.yaml#L31
     - msgpack-python >=1.0.2
     - ruamel.yaml
     - zstandard
@@ -37,7 +38,9 @@ test:
   source_files:
     - tests
   requires:
-    - conda-build >=24
+    # https://github.com/conda/conda-index/blob/0.7.0/conda_index/plugin.py#L22
+    - conda-build >=24.1
+    # https://github.com/conda/conda-index/blob/0.7.0/recipe/meta.yaml#L37
     - conda-package-handling >=2.2.0
     - coverage
     - pip


### PR DESCRIPTION
conda-index 0.7.0

**Destination channel:** defaults

### Links

- [PKG-10235](https://anaconda.atlassian.net/browse/PKG-10235) 
- [Upstream repository](https://github.com/conda/conda-index)

### Explanation of changes:
- Updating to 0.7.0


[PKG-10235]: https://anaconda.atlassian.net/browse/PKG-10235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ