### PR TITLE
V0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - click >=8
-    - conda >=4.14.0
+    - conda >=25
     - conda-package-streaming >=0.7.0
     - filelock
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.7.0" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: afbf3850b2197ab4ceb7785bee462e063bd498488c185112477cbe4197e70aad
+  sha256: 5c076270c9dc83b2694646697c7633ada02e781805e3edf1ec82cbba4fca8a6b
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
@@ -31,6 +31,8 @@ requirements:
     - msgpack-python >=1.0.2
     - ruamel.yaml
     - zstandard
+  run_constrained:
+    - conda-package-handling >=2
 
 test:
   imports:


### PR DESCRIPTION
conda-index v0.10.0

**Destination channel:** defaults

### Links

- [PKG-12574](https://anaconda.atlassian.net/browse/PKG-12574) 
- [Upstream repository](https://github.com/conda/conda-index/tree/0.10.0)
- [Upstream changelog/diff](https://github.com/conda/conda-index/releases/tag/0.10.0)

### Explanation of changes:

- Bump version and SHA
- Set 3.10 as minimum
- Adjust conda pinning based on [upstream conda recipe](https://github.com/conda/conda-index/blob/0.10.0/recipe/meta.yaml#L27)


[PKG-12574]: https://anaconda.atlassian.net/browse/PKG-12574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ