### PR TITLE
v0.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-index" %}
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 5c076270c9dc83b2694646697c7633ada02e781805e3edf1ec82cbba4fca8a6b
+  sha256: 2c3c223dea4dd4aa921e5f8f9fe72326cb7baaa561dbf1f0d842e4d6a2db3226
 
 build:
   number: 0
@@ -24,7 +24,7 @@ requirements:
     - python
     - click >=8
     - conda >=25
-    - conda-package-streaming >=0.7.0
+    - conda-package-streaming >=0.12.0
     - filelock
     - jinja2
     # https://github.com/conda/conda-index/blob/0.7.0/recipe/meta.yaml#L31
@@ -32,7 +32,7 @@ requirements:
     - ruamel.yaml
     - zstandard
   run_constrained:
-    - conda-package-handling >=2
+    - conda-package-handling >=1.9.0
 
 test:
   imports:


### PR DESCRIPTION
conda-index v0.11.0

**Destination channel:** defaults

### Links

- [PKG-13798](https://anaconda.atlassian.net/browse/PKG-13798) 
- [Upstream repository](https://github.com/conda/conda-index/tree/0.11.0)
- [Upstream changelog/diff](https://github.com/conda/conda-index/releases/tag/0.11.0)

### Explanation of changes:

- Bump version and SHA
- Update pinnings 


[PKG-13798]: https://anaconda.atlassian.net/browse/PKG-13798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ